### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/msphinternal/37759b66-31a7-4395-ab71-9e39d31a27fb/88ef1d0e-4f50-4cf2-b0c2-21f1f100dd15/_apis/work/boardbadge/b377074f-0f61-421a-8cb1-5ce139794dbf)](https://dev.azure.com/msphinternal/37759b66-31a7-4395-ab71-9e39d31a27fb/_boards/board/t/88ef1d0e-4f50-4cf2-b0c2-21f1f100dd15/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#410](https://dev.azure.com/msphinternal/37759b66-31a7-4395-ab71-9e39d31a27fb/_workitems/edit/410). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.